### PR TITLE
Fixed server unable to connect errors and potentially elevation error

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nuxt3socketKG.iml" filepath="$PROJECT_DIR$/.idea/nuxt3socketKG.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nuxt3socketKG.iml
+++ b/.idea/nuxt3socketKG.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuxt3socket",
+  "name": "nuxt3socketKG",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/plugins/websocket.client.ts
+++ b/plugins/websocket.client.ts
@@ -2,7 +2,10 @@ export default defineNuxtPlugin(() => {
   if (process.server) return
 
   const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
-  let socket = new WebSocket(`${wsProtocol}//${window.location.host}`)
+  const domain = window.location.hostname
+  const websocketPort = 8080
+
+  let socket = new WebSocket(`${wsProtocol}//${domain}:${websocketPort}`)
 
   return {
     provide: {

--- a/server/middleware/socket.ts
+++ b/server/middleware/socket.ts
@@ -14,14 +14,17 @@ declare global {
 let wss: WebSocketServer
 let clients: Client[] = []
 
+let port = 8080
+
 export default defineEventHandler((event) => {
-  
+
   if (!global.wss) {
-    wss = new WebSocketServer({ server: event.node.res.socket?.server })
-    
-    
+    // @ts-ignore
+    wss = new WebSocketServer({ port: port, host: event.node.res.socket?.server.address().address })
+
+
     wss.on("connection", function (socket) {
-  
+
       socket.send("connected")
 
       socket.on("message", function (message) {


### PR DESCRIPTION
The current way of creating the server WebSocket doesn't work for some reason.

I found out that it won't work unless we are listening on a different port.

The point of doing it the way it was originally was to avoid using multiple ports because some servers do not support it.

Nuxt3 as to my rather inept knowledge internally already uses a bunch of ports, for housekeeping so using one more for handling WebSocket connections shouldn't be much of an impact... hopefully.

Anyway, that is my contribution, a bunch of YouTube viewers are having issues. But I managed to mitigate some of them.
![Screenshot 2023-03-20 161839](https://user-images.githubusercontent.com/47557574/226356791-d3212b97-1a95-4e6a-a062-a7dd33be76aa.png)


